### PR TITLE
feat: add apple app store meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Deliteo es tu app para planificar y disfrutar recetas personalizadas. Muy pronto disponible.">
+  <meta name="apple-itunes-app" content="app-id=6748577096, app-argument=https://deliteo.com">
   <title>Deliteo — Próximamente</title>
   <meta property="og:title" content="Deliteo — Planifica tus recetas favoritas">
   <meta property="og:description" content="Estamos cocinando algo delicioso. Muy pronto Deliteo estará disponible.">

--- a/privacidad.html
+++ b/privacidad.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Política de privacidad de la app Deliteo.">
+  <meta name="apple-itunes-app" content="app-id=6748577096, app-argument=https://deliteo.com">
   <title>Política de privacidad · Deliteo</title>
   <link rel="icon" type="image/png" href="favicon.png" />
   <link rel="stylesheet" href="styles.css">


### PR DESCRIPTION
## Summary
- add `apple-itunes-app` meta tag to enable App Store smart banner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934d2c1370832bb2c1588364daeba3