### PR TITLE
Add English versions of index and privacy pages

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Deliteo helps you plan and enjoy personalized recipes. Coming soon.">
+  <meta name="apple-itunes-app" content="app-id=6748577096, app-argument=https://deliteo.com">
+  <title>Deliteo — Coming Soon</title>
+  <meta property="og:title" content="Deliteo — Plan your favorite recipes">
+  <meta property="og:description" content="We're cooking something delicious. Deliteo will be available soon.">
+  <meta property="og:image" content="https://deliteo.com/image.png">
+  <meta property="og:url" content="https://deliteo.com">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deliteo — Plan your favorite recipes">
+  <meta name="twitter:description" content="We're cooking something delicious. Deliteo will be available soon.">
+  <meta name="twitter:image" content="https://deliteo.com/image.png">
+  <link rel="icon" type="image/png" href="favicon.png">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    @media (prefers-color-scheme: dark) {
+      .app-store-badge {
+        content: url('https://tools.applemediaservices.com/api/badges/download-on-the-app-store/white/en-us?size=200x67');
+      }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="#">Home</a>
+    <a href="/privacy.html">Privacy Policy</a>
+  </nav>
+
+  <div class="container">
+    <img class="logo" src="image.png" alt="Deliteo logo">
+    <h1>Deliteo is cooking</h1>
+    <p>We are working on a new experience to help you plan and enjoy your favorite recipes. Coming soon!</p>
+    <div class="badge">Under construction</div>
+    <a href="https://apps.apple.com/us/app/deliteo/id6748577096">
+      <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=200x67" alt="Download on the App Store" class="app-store-badge">
+    </a>
+  </div>
+
+  <footer>
+    <p>&copy; 2025 Deliteo</p>
+  </footer>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Privacy policy for the Deliteo app.">
+  <meta name="apple-itunes-app" content="app-id=6748577096, app-argument=https://deliteo.com">
+  <title>Privacy Policy · Deliteo</title>
+  <link rel="icon" type="image/png" href="favicon.png" />
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/privacy.html">Privacy Policy</a>
+  </nav>
+
+  <div class="content">
+    <h1>Privacy Policy</h1>
+    <p><strong>Last updated:</strong> July 10, 2025</p>
+
+    <p>This Privacy Policy describes how Deliteo collects, uses and protects the personal information you may provide through our application.</p>
+
+    <h2>1. Information we collect</h2>
+    <p>Deliteo does not collect personally identifiable information such as name, email address or location. The app only stores data related to your recipe preferences, ingredients and settings locally on your device.</p>
+
+    <h2>2. How we use the information</h2>
+    <p>The data collected is used exclusively to provide features such as:</p>
+    <ul>
+      <li>Saving your recipes and shopping lists.</li>
+      <li>Remembering your dietary preferences and allergens.</li>
+      <li>Personalizing the in-app experience.</li>
+    </ul>
+
+    <h2>3. Local storage</h2>
+    <p>All information is stored locally on your device. It is not sent to external servers or shared with third parties.</p>
+
+    <h2>4. Permissions</h2>
+    <p>The app may request optional access to certain system functionalities, such as local storage, solely to enhance app functionality.</p>
+
+    <h2>5. Changes to this policy</h2>
+    <p>We reserve the right to modify this Privacy Policy at any time. We will notify you of any significant changes by updating this section.</p>
+
+    <h2>6. Contact</h2>
+    <p>If you have questions about this policy, you can write to us at <a href="mailto:contact@deliteo.com">contact@deliteo.com</a>.</p>
+
+    <p>By using Deliteo, you agree to this Privacy Policy.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add English index page with translated copy and App Store badge
- add English privacy policy page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f5cea550832b9fdc99d06365ceb5